### PR TITLE
(puppet-daq) added libreadline.so.7 simlink on RHEL9

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,5 +48,12 @@ class daq (
       group  => 'root',
       target => $readline,
     }
+
+    file { '/usr/lib64/libreadline.so.7':
+      ensure => link,
+      owner  => 'root',
+      group  => 'root',
+      target => $readline,
+    }
   }
 }


### PR DESCRIPTION
Now that DAQ is compiling on RHEL8, it's looking for libreadline.so.7 not libreadline.so.6 anymore. On RHEL 9, we'll need to add the symlink. I didn't change the spec since it wasn't checking on RHEL9 already.